### PR TITLE
Manual wrap and unwrap scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,35 +12,37 @@ Ubuntu Server 20.04
 To configure your  application, create a .env file with the following parameters in the root of the fio.oracle directory.
 
 ```
-MODE=                     # testnet or mainnet
-PORT=                     # The port that the fio.oracle service will run on when started
-FIO_SERVER_URL_HISTORY=   # URL of FIO history node
-FIO_SERVER_URL_ACTION=    # URL of FIO API node
-FIO_ORACLE_PUBLIC_KEY=    # The FIO public key used for approving unwrap transactions
-FIO_ORACLE_PRIVATE_KEY=   # The FIO private key used for approving unwrap transactions
-FIO_ORACLE_ACCOUNT=       # The FIO account used for approving unwrap transactions
-ETH_ORACLE_PUBLIC=        # The ETH oracle public key used for signing ERC20 transactions
-ETH_ORACLE_PRIVATE=       # The ETH oracle private key used for signing ERC20 transactions
-POLYGON_ORACLE_PUBLIC=    # The POLYGON oracle public key used for signing ERC721 transactions
-POLYGON_ORACLE_PRIVATE=   # The POLYGON oracle private key used for signing ERC721 transactions
-POLLTIME=                 # Seconds between poll for wrap and unwrap events (60 seconds=60000)
-POLLOFFSET=               # The number of wrap transactions to get on FIO side in each call (If you set 20, you can get 20 latest actions on FIO side)
-USEGASAPI=                # Boolean to use manual price an limit settings or user the API (0 = manual, 1 = use API)
-GASPRICELEVEL=            # Which price to use from the gas price API (low/average/high)
-TGASLIMIT=                # Manual gas limit for ETH erc20
-TGASPRICE=                # Manual gas price for ETH erc20
-PGASLIMIT=                # Manual gas limit for Polygon erc721
-PGASPRICE=                # Manual gas price for Polygon erc721
-ETH_API_URL=              # The Ethereum chain etherscan API URL 
-ETHINFURA=                # The Ethereum chain Infura API URL
-FIO_TOKEN_ETH_CONTRACT=       # Ethereum address of the erc20 token contract
-FIO_NFT_ETH_CONTRACT=         # Ethereum address of the erc721 NFT contract (Legacy, only supporting Polygon NFT for V1)
-POLYGON_API_URL=          # The Polygon chain polyscan API URL
-POLYGON_INFURA=           # The Polygon chain Infura API URL
-FIO_NFT_POLYGON_CONTRACT=     # The Polygon address of the erc721 NFT contract
-ETH_TESTNET_CHAIN_NAME=   # The Ethereum testnet chain name
-BLOCKS_RANGE_LIMIT_ETH=       # The limitation for Block numbers used for ETH chain to make pastEvents contract call
-BLOCKS_RANGE_LIMIT_POLY=       # The limitation for Block numbers used for Polygon chain to make pastEvents contract call
+MODE=                        # testnet or mainnet
+PORT=                        # The port that the fio.oracle service will run on when started
+FIO_SERVER_URL_HISTORY=      # URL of FIO history node
+FIO_SERVER_URL_ACTION=       # URL of FIO API node
+FIO_ORACLE_PUBLIC_KEY=       # The FIO public key used for approving unwrap transactions
+FIO_ORACLE_PRIVATE_KEY=      # The FIO private key used for approving unwrap transactions
+FIO_ORACLE_ACCOUNT=          # The FIO account used for approving unwrap transactions
+FIO_ORACLE_ADDRESS=          # The FIO Crypto Handle for the oracle
+ETH_ORACLE_PUBLIC=           # The ETH oracle public key used for signing ERC20 transactions
+ETH_ORACLE_PRIVATE=          # The ETH oracle private key used for signing ERC20 transactions
+POLYGON_ORACLE_PUBLIC=       # The POLYGON oracle public key used for signing ERC721 transactions
+POLYGON_ORACLE_PRIVATE=      # The POLYGON oracle private key used for signing ERC721 transactions
+POLLTIME=                    # Seconds between poll for wrap and unwrap events (60 seconds=60000)
+POLLOFFSET=                  # The number of wrap transactions to get on FIO side in each call (If you set 20, you can get 20 latest actions on FIO side)
+USEGASAPI=                   # Boolean to use manual price an limit settings or user the API (0 = manual, 1 = use API)
+GASPRICELEVEL=               # Which price to use from the gas price API (low/average/high)
+TGASLIMIT=                   # Manual gas limit for ETH erc20
+TGASPRICE=                   # Manual gas price for ETH erc20
+PGASLIMIT=                   # Manual gas limit for Polygon erc721
+PGASPRICE=                   # Manual gas price for Polygon erc721
+ETH_API_URL=                 # The Ethereum chain etherscan API URL 
+ETHINFURA=                   # The Ethereum chain Infura API URL
+FIO_TOKEN_ETH_CONTRACT=      # Ethereum address of the erc20 token contract
+FIO_NFT_ETH_CONTRACT=        # Ethereum address of the erc721 NFT contract (Legacy, only supporting Polygon NFT for V1)
+POLYGON_API_URL=             # The Polygon chain polyscan API URL
+POLYGON_INFURA=              # The Polygon chain Infura API URL
+FIO_NFT_POLYGON_CONTRACT=    # The Polygon address of the erc721 NFT contract
+ETH_TESTNET_CHAIN_NAME=      # The Ethereum testnet chain name (e.g., goerli)
+POLYGON_TESTNET_CHAIN_NAME=  # The Polygon testnet chain name (e.g., matic-mumbai)
+BLOCKS_RANGE_LIMIT_ETH=      # The limitation for Block numbers used for ETH chain to make pastEvents contract call
+BLOCKS_RANGE_LIMIT_POLY=      # The limitation for Block numbers used for Polygon chain to make pastEvents contract call
 ```
 
 ## Installation

--- a/controller/api/eth.js
+++ b/controller/api/eth.js
@@ -85,12 +85,17 @@ class EthCtrl {
                     const oraclePublicKey = process.env.ETH_ORACLE_PUBLIC;
                     const oraclePrivateKey = process.env.ETH_ORACLE_PRIVATE;
 
+                    // Commented this out. It was throwing an uncaught exception so I added the .catch, but still throws an error. 
+                    // We have changed how to check consensus.
                     // todo: check if we should make wrap call (maybe just jump to read logs file) in case of already approved transaction by current oracle (do not forget to await)
-                    this.fioContract.methods.getApproval(txIdOnFioChain).call()
-                        .then((response) => {
-                            console.log(logPrefix + 'Oracles Approvals:');
-                            console.log(response);
-                        });
+                    // this.fioContract.methods.getApproval(txIdOnFioChain).call()
+                    //     .then((response) => {
+                    //         console.log(logPrefix + 'Oracles Approvals:');
+                    //         console.log(response);
+                    //     }).catch(err => {
+                    //         console.log ('Error: ', err);
+                    //     });
+
                     if (this.web3.utils.isAddress(wrapData.public_address) === true && wrapData.chain_code === "ETH") { //check validation if the address is ERC20 address
                         console.log(logPrefix + `requesting wrap action of ${convertNativeFioIntoFio(quantity)} FIO tokens to ${wrapData.public_address}`)
                         const wrapTokensFunction = this.fioContract.methods.wrap(wrapData.public_address, quantity, txIdOnFioChain);
@@ -105,7 +110,7 @@ class EthCtrl {
                                 to: process.env.FIO_TOKEN_ETH_CONTRACT,
                                 data: wrapABI,
                                 from: oraclePublicKey,
-                                nonce: this.web3.utils.toHex(nonce),
+                                nonce: this.web3.utils.toHex(nonce)
                             },
                             { chain: process.env.MODE === 'testnet' ? process.env.ETH_TESTNET_CHAIN_NAME : 'mainnet' }
                         );
@@ -208,6 +213,7 @@ class EthCtrl {
             try {
                 const pubKey = process.env.ETH_ORACLE_PUBLIC;
                 const signKey = process.env.ETH_ORACLE_PRIVATE;
+                // TODO: Seeing some unexpected errors in logs. This may need an .catch(err => { ...
                 this.fioNftContract.methods.getApproval(tx_id).call()
                     .then((response) => {
                         console.log(response);

--- a/controller/api/fio.js
+++ b/controller/api/fio.js
@@ -339,7 +339,7 @@ class FIOCtrl {
             };
 
             const getUnprocessedActionsLogs = async () => {
-                const lastInChainBlockNumber = await web3.eth.getBlockNumber()
+                const lastInChainBlockNumber = await web3.eth.getBlockNumber();
                 const lastProcessedBlockNumber = getLastProceededBlockNumberOnEthereumChain();
 
                 if (lastProcessedBlockNumber > lastInChainBlockNumber)
@@ -349,7 +349,7 @@ class FIOCtrl {
 
                 let fromBlockNumber = lastProcessedBlockNumber + 1;
 
-                console.log(logPrefix + `start Block Number: ${fromBlockNumber}, end Block Number: ${lastInChainBlockNumber}`)
+                console.log(logPrefix + `start Block Number: ${fromBlockNumber}, end Block Number: ${lastInChainBlockNumber}`);
 
                 let result = [];
                 let maxCheckedBlockNumber = 0;
@@ -363,6 +363,7 @@ class FIOCtrl {
                             : maxAllowedBlockNumber;
 
                     maxCheckedBlockNumber = toBlockNumber;
+                    updateBlockNumberETH(maxCheckedBlockNumber.toString());
 
                     result = [
                         ...result,
@@ -371,8 +372,6 @@ class FIOCtrl {
 
                     fromBlockNumber = toBlockNumber + 1;
                 }
-
-                updateBlockNumberETH(maxCheckedBlockNumber.toString());
 
                 console.log(logPrefix + `events list:`);
                 console.log(result);
@@ -508,6 +507,7 @@ class FIOCtrl {
                             : maxAllowedBlockNumber;
 
                     maxCheckedBlockNumber = toBlockNumber;
+                    updateBlockNumberMATIC(maxCheckedBlockNumber.toString());
 
                     result = [
                         ...result,
@@ -516,8 +516,6 @@ class FIOCtrl {
 
                     fromBlockNumber = toBlockNumber + 1;
                 }
-
-                updateBlockNumberMATIC(maxCheckedBlockNumber.toString());
 
                 console.log(logPrefix + `events list:`);
                 console.log(result);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint src/js",
-    "dev": "cross-env nodemon -r esm server.js"
+    "dev": "cross-env nodemon -r esm server.js",
+    "oracle": "node scripts/oracle.js"
   },
   "author": "",
   "license": "ISC",
@@ -19,7 +20,7 @@
     "@babel/runtime": "^7.14.0",
     "@ethereumjs/common": "^2.6.5",
     "@fioprotocol/fiojs": "^1.0.1",
-    "@fioprotocol/fiosdk": "^1.2.1",
+    "@fioprotocol/fiosdk": "github:fioprotocol/fiosdk_typescript#release/1.8.x",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",

--- a/scripts/oracle.js
+++ b/scripts/oracle.js
@@ -1,0 +1,64 @@
+const {
+    unwrapTokens,
+    unwrapDomain,
+    wrapTokens,
+    wrapDomain
+} = require('./oracleutils.js');
+
+//console.log(process.env)
+//console.log('process.argv', process.argv);
+
+const args = process.argv;
+
+const oracle = {
+ usage: 
+ "Usage: npm run oracle ['wrap'|'unwrap'] ['tokens'|'domain'] [amount|domain] [fio handle or eth address] trxid \n \
+    Examples: \n \
+        npm run oracle wrap tokens 12000000000 0xe28FF0D44d533d15cD1f811f4DE8e6b1549945c9 ec52a13e3fd60c1a06ad3d9c0d66b97144aa020426d91cc43565483c743dd320 \n \
+        npm run oracle wrap domain fiohacker 0xe28FF0D44d533d15cD1f811f4DE8e6b1549945c9 ec52a13e3fd60c1a06ad3d9c0d66b97144aa020426d91cc43565483c743dd320 \n \
+        npm run oracle unwrap tokens 12000000000 alice@fiotestnet ec52a13e3fd60c1a06ad3d9c0d66b97144aa020426d91cc43565483c743dd320 \n \
+        npm run oracle unwrap domain fiohacker alice@fiotestnet ec52a13e3fd60c1a06ad3d9c0d66b97144aa020426d91cc43565483c743dd320",
+ action: args.length > 2 ? args[2] + args[3] : 'help',
+ domain: args[3] == 'domain' ? args[4] : '',
+ amount: args[3] == 'tokens' ? args[4] : '',
+ address: args[5],
+ obtid: args[6]
+}
+
+const main = async () => {
+    try {
+        let result;
+        switch (oracle.action) {
+            case 'help':
+                console.log(oracle.usage + '\n');
+                break;
+            case 'wraptokens':
+                result = await wrapTokens(oracle.amount, oracle.address, oracle.obtid);
+                console.log('Result: ', result);
+                break;
+            case 'wrapdomain':
+                result = await wrapDomain(oracle.domain, oracle.address, oracle.obtid);
+                console.log('Result: ', result);
+                break;
+            case 'unwraptokens':
+                result = await unwrapTokens(oracle.amount, oracle.address, oracle.obtid);
+                console.log('Result: ', result);
+                break;
+            case 'unwrapdomain':
+                result = await unwrapDomain(oracle.domain, oracle.address, oracle.obtid);
+                console.log('Result: ', result);
+                break;
+            default:
+                console.log(`\nAction ${oracle.action} not found\n`);
+                console.log(oracle.usage + '\n')
+        }
+
+    } catch (err) {
+        console.log('\nError: ', err);
+        if (err.json) {
+            console.log('\nDetails: ', err.json);
+        }
+    }
+}
+
+main();

--- a/scripts/oracleutils.js
+++ b/scripts/oracleutils.js
@@ -1,0 +1,80 @@
+const {FIOSDK } = require('@fioprotocol/fiosdk');
+const fetch = require('node-fetch');
+require('dotenv').config();
+
+const fioABI = require('../config/ABI/FIO.json');
+const fioNftABI = require('../config/ABI/FIONFT.json');
+const Web3 = require('web3');
+const web3 = new Web3(process.env.ETHINFURA);
+const fioContract = new web3.eth.Contract(fioABI, process.env.FIO_TOKEN_ETH_CONTRACT);
+const fioNftContract = new web3.eth.Contract(fioNftABI, process.env.FIO_NFT_POLYGON_CONTRACT);
+
+const baseUrl = process.env.FIO_SERVER_URL_ACTION + 'v1/',
+  privateKey = process.env.FIO_ORACLE_PRIVATE_KEY,
+  publicKey = process.env.FIO_ORACLE_PUBLIC_KEY,
+  fioAddress = process.env.FIO_ORACLE_ADDRESS,
+  ethPubAddress = process.env.ETH_ORACLE_PUBLIC,
+  polyPubAddress = process.env.POLYGON_ORACLE_PUBLIC,
+  gas = process.env.TGASLIMIT,
+  gasPrice = process.env.TGASPRICE.toString() + "000000000000"
+
+const fetchJson = async (uri, opts = {}) => {
+  return fetch(uri, opts)
+}
+
+const user = new FIOSDK(
+  privateKey,
+  publicKey,
+  baseUrl,
+  fetchJson
+)
+
+const wrapTokens = async (amount, account, obtid) => {
+  const result = fioContract.methods
+    .wrap(account, amount, obtid)
+    .send({ 
+      from: ethPubAddress,
+      gas: gas,  // Limit
+      gasPrice: gasPrice
+    });
+  return result;
+}
+
+const wrapDomain = async (domain, account, obtid) => {
+  const result = fioNftContract.methods
+    .wrapnft(account, domain, obtid)
+    .send({ 
+      from: polyPubAddress,
+      gas: gas,  // Limit
+      gasPrice: gasPrice
+    });
+  return result;
+}
+
+const unwrapTokens = async (amount, address, obtid) => {
+  const result = await user.genericAction('pushTransaction', {
+    action: 'unwraptokens',
+    account: 'fio.oracle',
+    data: {
+      amount: amount,
+      obt_id: obtid,
+      fio_address: address
+    }
+  });
+  return result;
+}
+
+const unwrapDomain = async (domain, address, obtid) => {
+  await user.genericAction('pushTransaction', {
+    action: 'unwrapdomain',
+    account: 'fio.oracle',
+    data: {
+      fio_domain: domain,
+      obt_id: obtid,
+      fio_address: address
+    }
+});
+  return result;
+}
+
+module.exports = {unwrapTokens, unwrapDomain, wrapTokens, wrapDomain};


### PR DESCRIPTION
Fixes error where blockNumberETH.log and blockNumberMATIC.log was getting reset to zero in certain cases causing a resubmission of wrap transactions.

Adding scripts for oracle BPs so they can submit manual wraps and unwraps for failed transactions.

Added BLOCKS_RANGE_LIMIT_ETH and BLOCKS_RANGE_LIMIT_POLY to the Readme.